### PR TITLE
kitten: pass results through chaining steps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitten"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["Andy Davis <github@andy-davis.co.uk>", "Matthew Weller <wellm018@gmail.com>", "Kyle Manning <k_manning@live.co.uk>"]
 edition = "2018"
 description = "Kitten is a light bdd framework for Rust and for those who don't like cucumber - cats don't like cucumbers."


### PR DESCRIPTION
The SUT (System Under Test) was being passed throughout the given/when/then steps of Kitten, making it difficult to assert on results produced within different sections of the chain.

By adding generics to the lambdas each step accepts, we can make it so Kitten feeds each output of a step as the input of the next one.

Furthermore, if we are able to pass results generically, we can also collect and flow results into latter steps into the chain via tuples.