### PR TITLE
feat: allows closures to capture variables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,16 @@
 [package]
 name = "kitten"
-version = "0.2.0"
-authors = ["Andy Davis <github@andy-davis.co.uk>", "Matthew Weller <wellm018@gmail.com>", "Kyle Manning <k_manning@live.co.uk>"]
+version = "0.3.0"
+authors = [
+  "Andy Davis <github@andy-davis.co.uk>",
+  "Matthew Weller <wellm018@gmail.com>",
+  "Kyle Manning <k_manning@live.co.uk>",
+  "Rick Bolton <rickbolton@outlook.com>",
+]
 edition = "2018"
 description = "Kitten is a light bdd framework for Rust and for those who don't like cucumber - cats don't like cucumbers."
-license = "Apache-2.0" 
-documentation = "https://docs.rs/kitten/0.1.4/kitten/"
+license = "Apache-2.0"
+documentation = "https://docs.rs/kitten/0.3.0/kitten/"
 homepage = "https://github.com/majikandy/kitten"
 repository = "https://github.com/majikandy/kitten"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 pub struct Kitten;
 
 impl Kitten {
-    pub fn given<Result>(function: fn() -> Result) -> GivenAnd<Result> {
+    pub fn given<Result>(function: impl Fn() -> Result) -> GivenAnd<Result> {
         let result = function();
         GivenAnd { data: result }
     }
@@ -12,12 +12,12 @@ pub struct GivenAnd<T> {
 }
 
 impl<Input> GivenAnd<Input> {
-    pub fn and<Result>(self, function: fn(Input) -> Result) -> GivenAnd<Result> {
+    pub fn and<Result>(self, function: impl Fn(Input) -> Result) -> GivenAnd<Result> {
         let result = function(self.data);
         GivenAnd { data: result }
     }
 
-    pub fn when<Result>(self, function: fn(Input) -> Result) -> When<Result> {
+    pub fn when<Result>(self, function: impl Fn(Input) -> Result) -> When<Result> {
         let result = function(self.data);
         When { data: result }
     }
@@ -28,7 +28,7 @@ pub struct When<T> {
 }
 
 impl<Input> When<Input> {
-    pub fn then<Result>(self, function: fn(Input) -> Result) -> Then<Result> {
+    pub fn then<Result>(self, function: impl Fn(Input) -> Result) -> Then<Result> {
         let result = function(self.data);
         Then { data: result }
     }
@@ -39,7 +39,7 @@ pub struct Then<T> {
 }
 
 impl<Input> Then<Input> {
-    pub fn and<Result>(self, function: fn(Input) -> Result) -> Then<Result> {
+    pub fn and<Result>(self, function: impl Fn(Input) -> Result) -> Then<Result> {
         let result = function(self.data);
         Then { data: result }
     }
@@ -61,10 +61,10 @@ mod tests {
             })
             .when(|result| {
                 assert_eq!(result, String::from("another type"));
-                ()
+                1
             })
             .then(|result| {
-                assert_eq!(result, ());
+                assert_eq!(result, 1);
                 vec!["this", "is", "a", "list"]
             })
             .and(|result| assert_eq!(result, vec!["this", "is", "a", "list"]));
@@ -77,7 +77,6 @@ mod tests {
             .then(the_answer_is_3_checked_via_a_function);
     }
     #[test]
-
     fn it_works_with_named_functions_closures_and_closures_that_call_functions() {
         Kitten::given(a_calculator) // last return in given chain passed to when
             .when(adding_1_and_2_via_a_function)
@@ -88,11 +87,31 @@ mod tests {
             .and(the_answer_is_3_checked_via_a_function);
     }
 
+    #[test]
+    fn it_works_with_closures_that_capture_variables() {
+        let example = "example";
+
+        Kitten::given(|| 10)
+            .and(|result| {
+                assert_eq!(result, 10);
+                String::from("another type")
+            })
+            .when(|result| {
+                assert_eq!(result, String::from("another type"));
+                format!("test-{}", example)
+            })
+            .then(|result| {
+                assert_eq!(result, "test-example".to_string());
+                vec!["this", "is", "a", "list"]
+            })
+            .and(|result| assert_eq!(result, vec!["this", "is", "a", "list"]));
+    }
+
     fn adding_1_and_2_via_a_function(c: Calculator) -> i32 {
         c.add(1, 2)
     }
 
-    fn the_answer_is_3_checked_via_a_function(the_answer: i32) -> () {
+    fn the_answer_is_3_checked_via_a_function(the_answer: i32) {
         assert_eq!(the_answer.clone(), 3);
     }
 


### PR DESCRIPTION
Feature to allow closures to capture variables for example returning:

```rs
format!("test-{}", example)
```
